### PR TITLE
Fix bug when field gets converted to blacklisted word

### DIFF
--- a/json_to_models/models/base.py
+++ b/json_to_models/models/base.py
@@ -105,11 +105,11 @@ class GenericModelCodeGenerator:
 
     @cached_method
     def convert_class_name(self, name):
-        return prepare_label(name, convert_unicode=self.convert_unicode)
+        return prepare_label(name, convert_unicode=self.convert_unicode, to_snake_case=False)
 
     @cached_method
     def convert_field_name(self, name):
-        return inflection.underscore(prepare_label(name, convert_unicode=self.convert_unicode))
+        return prepare_label(name, convert_unicode=self.convert_unicode, to_snake_case=True)
 
     def generate(self, nested_classes: List[str] = None, bases: str = None, extra: str = "") \
             -> Tuple[ImportPathList, str]:
@@ -279,13 +279,15 @@ def sort_kwargs(kwargs: dict, ordering: Iterable[Iterable[str]]) -> dict:
     return sorted_dict
 
 
-def prepare_label(s: str, convert_unicode: bool) -> str:
-    if s in blacklist_words:
-        s += "_"
+def prepare_label(s: str, convert_unicode: bool, to_snake_case: bool) -> str:
     if convert_unicode:
         s = unidecode(s)
     s = re.sub(r"\W", "", s)
     if not ('a' <= s[0].lower() <= 'z'):
         if '0' <= s[0] <= '9':
             s = ones[int(s[0])] + "_" + s[1:]
+    if to_snake_case:
+        s = inflection.underscore(s)
+    if s in blacklist_words:
+        s += "_"
     return s

--- a/test/test_code_generation/test_attrs_generation.py
+++ b/test/test_code_generation/test_attrs_generation.py
@@ -29,7 +29,6 @@ def test_attrib_kwargs_sort():
         assert 0, "XPass"
 
 
-
 def field_meta(original_name):
     return f"metadata={{'{METADATA_FIELD_NAME}': '{original_name}'}}"
 
@@ -90,6 +89,7 @@ test_data = {
             "qwerty": FloatString,
             "asdfg": DOptional(int),
             "dict": DDict(int),
+            "ID": int,
             "not": bool,
             "1day": int,
             "день_недели": str,
@@ -125,6 +125,11 @@ test_data = {
                 "type": "Dict[str, int]",
                 "body": f"attr.ib({field_meta('dict')})"
             },
+            "ID": {
+                "name": "id_",
+                "type": "int",
+                "body": f"attr.ib({field_meta('ID')})"
+            },
             "not": {
                 "name": "not_",
                 "type": "bool",
@@ -155,6 +160,7 @@ test_data = {
             foo: int = attr.ib()
             qwerty: FloatString = attr.ib()
             dict_: Dict[str, int] = attr.ib({field_meta('dict')})
+            id_: int = attr.ib({field_meta('ID')})
             not_: bool = attr.ib({field_meta('not')})
             one_day: int = attr.ib({field_meta('1day')})
             den_nedeli: str = attr.ib({field_meta('день_недели')})


### PR DESCRIPTION
I found out that if a field name contains upper-case letters, then the underscore won't be appended to the resulting field name if it is reserved (blacklisted, in terms of the project). For example, one might expect `ID` to be converted to `id_` but it appears as `id` in the model. 

The solution is to change the order of string operations:
1. Convert unicode
2. Get rid of non-word characters
3. Make sure the field name starts with a letter
4. Convert to camel case
5. Check if the field name is blacklisted