### PR TITLE
Fix `generate` method to work with lists and dicts

### DIFF
--- a/json_to_models/generator.py
+++ b/json_to_models/generator.py
@@ -46,6 +46,8 @@ class MetadataGenerator:
         """
         Convert given list of data variants to metadata dict
         """
+        if isinstance(data_variants[0], list):
+            data_variants = [item for sublist in data_variants for item in sublist]
         fields_sets = [self._convert(data) for data in data_variants]
         fields = self.merge_field_sets(fields_sets)
         return self.optimize_type(fields)
@@ -54,13 +56,13 @@ class MetadataGenerator:
         """
         Key and string value converting
         """
-        fields = dict()
+        fields = {}
         for key, value in data.items():
             if not isinstance(key, str):
-                raise TypeError(f'You probably using some not JSON-compatible parser and have some {type(key)} as dict key. '
+                raise TypeError(f'You are probably using a parser that is not JSON compatible and have data with some {type(key)}s as dict keys. '
                                 f'This is not supported.\n'
                                 f'Context: {data}\n'
-                                f'(If you parsing yaml try to replace PyYaml with ruamel.yaml)')
+                                f'(If you are parsing yaml, try replacing PyYaml with ruamel.yaml)')
             convert_dict = key not in self.dict_keys_fields
             fields[key] = self._detect_type(value, convert_dict)
         return fields


### PR DESCRIPTION
This is a bug fix for cases where the top level data structure in a file is a list, not a dictionary.

e.g. try running json2models with `test/test_cli/data/users.json` as the input:

```py
Traceback (most recent call last):
  File "/json2python/json_to_models/__main__.py", line 4, in <module>
    main()
  File "/json2python/json_to_models/cli.py", line 395, in main
    print(cli.run())
  File "/json2python/json_to_models/cli.py", line 121, in run
    meta = generator.generate(*data)
  File "/json2python/json_to_models/generator.py", line 49, in generate
    fields_sets = [self._convert(data) for data in data_variants]
  File "/json2python/json_to_models/generator.py", line 49, in <listcomp>
    fields_sets = [self._convert(data) for data in data_variants]
  File "/json2python/json_to_models/generator.py", line 58, in _convert
    for key, value in data.items():
AttributeError: 'list' object has no attribute 'items'
```

Flattening out the input lists in the `generate` method allows files like this to be parsed correctly.